### PR TITLE
fix: adjust exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "license": "Apache-2.0",
   "main": "tsconfig.json",
   "exports": {
-    "import": "./tsconfig.json",
-    "require": "./tsconfig.json"
+    ".": "./tsconfig.json"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
I tried adopting rsbuild in apify-client, and it fails because of how we define the exports field here. This fixes it, and feels more correct than what we had before. Alternatively, we can just drop it completely, that also works.