### PR TITLE
chore: drop deprecated importsNotUsedAsValues option

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
 		"experimentalDecorators": true,
 		"forceConsistentCasingInFileNames": true,
 		"importHelpers": true,
-		"importsNotUsedAsValues": "remove",
 		"incremental": true,
 		"lib": ["ESNext"],
 		"module": "CommonJS",


### PR DESCRIPTION
## Summary

The \`importsNotUsedAsValues\` option was deprecated in TypeScript 5.0 and fully removed in newer toolchains (e.g. \`tsgolint\`, which powers \`oxlint --type-aware\`, refuses to parse tsconfigs that contain it).

Since TS 5.0, the value \`"remove"\` has been the default behavior, so dropping it from this shared config is a no-op for consumers on any supported TypeScript version. It only removes a compat headache.

A new release after merging would unblock Crawlee v4 (apify/crawlee#3569) from migrating to oxlint with type-aware linting enabled without having to carry a local yarn patch.