### PR TITLE
feat: modernize tsconfig to >= node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/tsconfig",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "TypeScript configuration shared across projects in Apify.",
   "author": "Vlad Frangu <vlad.frangu@apify.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apify/tsconfig",
-  "version": "0.2.0",
+  "version": "0.1.2",
   "description": "TypeScript configuration shared across projects in Apify.",
   "author": "Vlad Frangu <vlad.frangu@apify.com>",
   "license": "Apache-2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"importHelpers": true,
 		"incremental": true,
-		"lib": ["ESNext"],
-		"module": "nodenext",
+		"lib": ["ES2023"],
+		"module": "node20",
 		"moduleResolution": "nodenext",
 		"newLine": "lf",
 		"noEmitHelpers": true,
@@ -27,7 +27,7 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"target": "esnext",
+		"target": "es2023",
 		"useDefineForClassFields": true
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
 		"importHelpers": true,
 		"incremental": true,
 		"lib": ["ESNext"],
-		"module": "CommonJS",
-		"moduleResolution": "Node",
+		"module": "nodenext",
+		"moduleResolution": "nodenext",
 		"newLine": "lf",
 		"noEmitHelpers": true,
 		"noFallthroughCasesInSwitch": true,
@@ -27,7 +27,7 @@
 		"resolveJsonModule": true,
 		"sourceMap": true,
 		"strict": true,
-		"target": "ES2019",
+		"target": "esnext",
 		"useDefineForClassFields": true
 	}
 }


### PR DESCRIPTION
Updates config to match modern node config.
- gets rid of `node` (`node10`) as `moduleResolution`. Switch to `nodenext` for the `.js` extension enforcement on imports.
- Since its on `nodenext`, `module` has to be that as well.
- `target` bumped to `esnext` (compatible with node >= 22). Additionally, `lib` was already `ESNext` which could have broken on earlier versions of node due to missing polyfills coming from the mismatch of `lib = ESNext` and `target = ES2019`.

bumped minor version since this might be a breaking change for outdated projects