### PR TITLE
chore(ci): Use `signed-commit` action when releasing new versions

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -50,45 +50,40 @@ jobs:
         id: get_version
         run: echo "VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      # We need to create a commit and tag for the new version so that git-cliff can
-      # get the current version to generate the changelog.
-      # This commit will be ignored by git-cliff because of its title.
-      - name: Commit version bump
-        run: |
-          # Add a newline to CHANGELOG.md so that there is always a change to commit, even if the version was bumped manually before.
-          # CHANGELOG.md will be regenerated later with git-cliff, so this is a noop.
-          echo "" >> CHANGELOG.md
-          git config user.name "Apify Release Bot"
-          git config user.email "noreply@apify.com"
-          git add .
-          git commit -m "chore(release): Release new version [skip ci]"
-          git tag "v${{ steps.get_version.outputs.VERSION }}"
-
       - name: Generate full changelog
         id: git-cliff
         uses: orhun/git-cliff-action@v4
+        with:
+          args: --tag "v${{ steps.get_version.outputs.VERSION }}"
         env:
           OUTPUT: CHANGELOG.md
 
-      - name: Amend commit with updated changelog
-        run: |
-          git add CHANGELOG.md
-          git commit --amend --no-edit
-          # Move the tag to point to the amended commit
-          git tag -f "v${{ steps.get_version.outputs.VERSION }}"
+      - name: Commit release
+        id: commit-release
+        uses: apify/actions/signed-commit@v1.2.0
+        with:
+          message: "chore(release): Release new version [skip ci]"
+          github-token: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
 
       - name: Publish to NPM
         run: npm publish --access public
 
-      - name: Push changes
-        run: git push origin $(git rev-parse --abbrev-ref HEAD) --tags
+      - name: Create and push tag
+        env:
+          GH_TOKEN: ${{ secrets.APIFY_SERVICE_ACCOUNT_GITHUB_TOKEN }}
+          TAG_NAME: "v${{ steps.get_version.outputs.VERSION }}"
+          COMMIT_SHA: ${{ steps.commit-release.outputs.commit_sha }}
+        run: |
+          gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            -f ref="refs/tags/${TAG_NAME}" \
+            -f sha="${COMMIT_SHA}"
 
       # Generate release notes only from the current version
       - name: Generate changelog for release notes
         id: git-cliff-release-notes
         uses: orhun/git-cliff-action@v4
         with:
-          args: --current --strip all
+          args: --tag "v${{ steps.get_version.outputs.VERSION }}" --current --strip all
 
       - name: Format release notes
         id: format-release-notes


### PR DESCRIPTION
We want to use signed commits everywhere. This updates the release workflow to use the `signed-commit` action. I've  copied and adjusted the publication workflow from https://github.com/apify/apify-oxlint-config/, so there should be no surprises.