### PR TITLE
ci: Expand abbreviated SHA to full when creating release tag

### DIFF
--- a/.github/workflows/publish_to_npm.yaml
+++ b/.github/workflows/publish_to_npm.yaml
@@ -74,9 +74,12 @@ jobs:
           TAG_NAME: "v${{ steps.get_version.outputs.VERSION }}"
           COMMIT_SHA: ${{ steps.commit-release.outputs.commit_sha }}
         run: |
+          # `signed-commit` outputs an abbreviated SHA, but the git refs API
+          # requires the full 40-character SHA — expand it first.
+          FULL_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT_SHA}" --jq '.sha')
           gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
             -f ref="refs/tags/${TAG_NAME}" \
-            -f sha="${COMMIT_SHA}"
+            -f sha="${FULL_SHA}"
 
       # Generate release notes only from the current version
       - name: Generate changelog for release notes


### PR DESCRIPTION
Same bug that broke publishing in [apify/apify-oxlint-config#20](https://github.com/apify/apify-oxlint-config/pull/20) — this repo's `publish_to_npm.yaml` has the identical setup.

The `apify/actions/signed-commit` action outputs an **abbreviated** commit SHA, but `POST /git/refs` requires the full 40-character SHA (`"At least 40 characters are required"`). As a result the release tag creation fails *after* NPM publish has already succeeded, leaving a published version with no git tag or GitHub release.

Fix: resolve the full SHA via the commits API before creating the ref.

```bash
FULL_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT_SHA}" --jq '.sha')
gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
  -f ref="refs/tags/${TAG_NAME}" \
  -f sha="${FULL_SHA}"
```